### PR TITLE
Add reaction ingestion and engagement analytics endpoints

### DIFF
--- a/src/config/adminjs.js
+++ b/src/config/adminjs.js
@@ -1,6 +1,6 @@
 import AdminJS from 'adminjs';
 import * as AdminJSMongoose from '@adminjs/mongoose';
-import { Player, Message, AdminUser } from '../models/index.js';
+import { Player, Message, AdminUser, MessageReaction } from '../models/index.js';
 import { DeletedMessageStats, DailyDeletion } from '../models/index.js';
 import { PrefilterResult } from '../models/index.js';
 import { GamingGroup } from '../models/index.js';
@@ -443,6 +443,56 @@ export const adminJS = new AdminJS({
       }
     },
     {
+      resource: MessageReaction,
+      options: {
+        list: {
+          perPage: DEFAULT_LIST_PER_PAGE,
+        },
+        actions: withDefaultListPerPage({
+          new: { isAccessible: false },
+          edit: { isAccessible: false },
+          delete: { isAccessible: isAdmin },
+          bulkDelete: { isAccessible: isAdmin },
+          list: { isAccessible: true },
+          show: { isAccessible: true },
+        }),
+        navigation: {
+          name: 'Engagement',
+          icon: 'ThumbsUp'
+        },
+        sort: {
+          sortBy: 'reacted_at',
+          direction: 'desc'
+        },
+        listProperties: [
+          'message_id',
+          'user_id',
+          'username',
+          'reaction',
+          'reacted_at',
+          'source'
+        ],
+        filterProperties: [
+          'message_id',
+          'user_id',
+          'reaction',
+          'source',
+          'reacted_at'
+        ],
+        showProperties: [
+          'message_id',
+          'user_id',
+          'username',
+          'reaction',
+          'reacted_at',
+          'source',
+          'metadata',
+          'createdAt',
+          'updatedAt'
+        ]
+      }
+    },
+    {
       resource: AdminUser,
       options: {
         list: {
@@ -502,7 +552,9 @@ export const adminJS = new AdminJS({
           CanceledUser: 'Canceled User',
           canceledUsers: 'Canceled Users',
           UserMessage: 'User Message',
-          userMessages: 'User Messages'
+          userMessages: 'User Messages',
+          MessageReaction: 'Message Reaction',
+          messageReactions: 'Message Reactions'
         }
       }
     }

--- a/src/controllers/reactionController.js
+++ b/src/controllers/reactionController.js
@@ -1,0 +1,173 @@
+import { engagementMetricsService } from '../services/engagementMetricsService.js';
+import { handleAsyncError } from '../utils/errorHandler.js';
+import { createServiceLogger } from '../utils/logger.js';
+import { parseDateInput, resolveTimeRange } from '../utils/timeRange.js';
+import { validateMessageId } from '../utils/validators.js';
+import { MESSAGE_REACTIONS } from '../models/MessageReaction.js';
+
+const reactionLogger = createServiceLogger('reaction-controller');
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 100;
+
+const parsePagination = (value, fallback) => {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+};
+
+export const reactionController = {
+  create: handleAsyncError(async (req, res) => {
+    const { message_id, user_id, username, reaction, reacted_at, source, metadata } = req.body;
+
+    if (!validateMessageId(message_id)) {
+      return res.status(400).json({ error: 'message_id must be an integer' });
+    }
+
+    if (!user_id || typeof user_id !== 'string') {
+      return res.status(400).json({ error: 'user_id is required' });
+    }
+
+    if (!reaction || !MESSAGE_REACTIONS.includes(reaction)) {
+      return res.status(400).json({ error: `reaction must be one of ${MESSAGE_REACTIONS.join(', ')}` });
+    }
+
+    let reactionDate = undefined;
+    if (reacted_at) {
+      const parsedDate = parseDateInput(reacted_at);
+      if (!parsedDate) {
+        return res.status(400).json({ error: 'reacted_at must be a valid ISO date' });
+      }
+      reactionDate = parsedDate;
+    }
+
+    if (metadata && typeof metadata !== 'object') {
+      return res.status(400).json({ error: 'metadata must be an object if provided' });
+    }
+
+    const recorded = await engagementMetricsService.recordReaction({
+      message_id: Number.parseInt(message_id, 10),
+      user_id,
+      username,
+      reaction,
+      reacted_at: reactionDate,
+      source,
+      metadata: metadata ?? null
+    });
+
+    reactionLogger.info('Reaction recorded', {
+      message_id: recorded.message_id,
+      user_id: recorded.user_id,
+      reaction: recorded.reaction
+    });
+
+    res.status(201).json(recorded);
+  }),
+
+  list: handleAsyncError(async (req, res) => {
+    const {
+      page = DEFAULT_PAGE,
+      limit = DEFAULT_LIMIT,
+      message_id,
+      user_id,
+      reaction,
+      source,
+      since,
+      until
+    } = req.query;
+
+    const resolvedPage = parsePagination(page, DEFAULT_PAGE);
+    const resolvedLimit = parsePagination(limit, DEFAULT_LIMIT);
+
+    if (message_id !== undefined && message_id !== null && message_id !== '') {
+      if (!validateMessageId(message_id)) {
+        return res.status(400).json({ error: 'message_id must be an integer' });
+      }
+    }
+
+    if (reaction && !MESSAGE_REACTIONS.includes(reaction)) {
+      return res.status(400).json({ error: `reaction must be one of ${MESSAGE_REACTIONS.join(', ')}` });
+    }
+
+    let start = null;
+    let end = null;
+
+    if (since || until) {
+      start = parseDateInput(since);
+      end = parseDateInput(until);
+
+      if ((since && !start) || (until && !end) || (start && end && start > end)) {
+        return res.status(400).json({ error: 'Invalid date range supplied' });
+      }
+    }
+
+    const data = await engagementMetricsService.listReactions({
+      page: resolvedPage,
+      limit: resolvedLimit,
+      messageId: message_id,
+      userId: user_id,
+      reaction,
+      source,
+      start,
+      end
+    });
+
+    res.json(data);
+  }),
+
+  getSummary: handleAsyncError(async (req, res) => {
+    const { timeframe, since, until } = req.query;
+
+    let range = null;
+
+    if (since || until) {
+      const start = parseDateInput(since);
+      const end = parseDateInput(until);
+      if ((since && !start) || (until && !end) || (start && end && start > end)) {
+        return res.status(400).json({ error: 'Invalid date range supplied' });
+      }
+      range = { start: start ?? null, end: end ?? null };
+    } else {
+      range = resolveTimeRange({ timeframe });
+      if (!range) {
+        return res.status(400).json({ error: 'Invalid timeframe supplied' });
+      }
+    }
+
+    const summary = await engagementMetricsService.getGlobalSummary({
+      start: range.start,
+      end: range.end
+    });
+
+    res.json(summary);
+  }),
+
+  getMessageSummary: handleAsyncError(async (req, res) => {
+    const { messageId } = req.params;
+
+    if (!validateMessageId(messageId)) {
+      return res.status(400).json({ error: 'messageId must be an integer' });
+    }
+
+    const summary = await engagementMetricsService.getMessageSummary(Number.parseInt(messageId, 10));
+
+    if (!summary) {
+      return res.status(404).json({ error: 'Message not found' });
+    }
+
+    res.json(summary);
+  }),
+
+  getUserSummary: handleAsyncError(async (req, res) => {
+    const { userId } = req.params;
+
+    if (!userId) {
+      return res.status(400).json({ error: 'userId is required' });
+    }
+
+    const summary = await engagementMetricsService.getUserSummary(userId);
+    res.json(summary);
+  })
+};

--- a/src/models/MessageReaction.js
+++ b/src/models/MessageReaction.js
@@ -1,0 +1,46 @@
+import mongoose from 'mongoose';
+
+const ALLOWED_REACTIONS = ['👍', '❤️', '👎'];
+
+const MessageReactionSchema = new mongoose.Schema({
+  message_id: {
+    type: Number,
+    required: true
+  },
+  user_id: {
+    type: String,
+    required: true
+  },
+  username: {
+    type: String,
+    default: null
+  },
+  reaction: {
+    type: String,
+    enum: ALLOWED_REACTIONS,
+    required: true
+  },
+  reacted_at: {
+    type: Date,
+    default: Date.now
+  },
+  source: {
+    type: String,
+    default: 'bot-crawler'
+  },
+  metadata: {
+    type: mongoose.Schema.Types.Mixed,
+    default: null
+  }
+}, {
+  timestamps: true
+});
+
+MessageReactionSchema.index({ message_id: 1, user_id: 1 }, { unique: true });
+MessageReactionSchema.index({ user_id: 1, reacted_at: -1 });
+MessageReactionSchema.index({ reaction: 1 });
+MessageReactionSchema.index({ reacted_at: -1 });
+MessageReactionSchema.index({ source: 1 });
+
+export const MessageReaction = mongoose.model('MessageReaction', MessageReactionSchema);
+export const MESSAGE_REACTIONS = ALLOWED_REACTIONS;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -7,4 +7,5 @@ export * from './GamingGroup.js';
 export * from './UserSeen.js';
 export * from './CanceledUser.js';
 export * from './UserMessage.js';
+export * from './MessageReaction.js';
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ import gamingGroupRoutes from './gamingGroups.js';
 import canceledUserRoutes from './canceledUsers.js';
 import userMessageRoutes from './userMessages.js';
 import userSeenRoutes from './userSeen.js';
+import reactionRoutes from './reactions.js';
 
 const router = express.Router();
 
@@ -23,5 +24,6 @@ router.use('/gaming-groups', gamingGroupRoutes);
 router.use('/canceled-users', canceledUserRoutes);
 router.use('/user-messages', userMessageRoutes);
 router.use('/user-seen', userSeenRoutes);
+router.use('/reactions', reactionRoutes);
 
 export default router;

--- a/src/routes/reactions.js
+++ b/src/routes/reactions.js
@@ -1,0 +1,249 @@
+import express from 'express';
+import { reactionController } from '../controllers/reactionController.js';
+import { authMiddleware, authorizeRole } from '../middleware/auth.js';
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     MessageReaction:
+ *       type: object
+ *       required:
+ *         - message_id
+ *         - user_id
+ *         - reaction
+ *       properties:
+ *         message_id:
+ *           type: integer
+ *           description: Telegram message identifier
+ *         user_id:
+ *           type: string
+ *           description: Telegram user identifier
+ *         username:
+ *           type: string
+ *         reaction:
+ *           type: string
+ *           enum: ['👍', '❤️', '👎']
+ *         reacted_at:
+ *           type: string
+ *           format: date-time
+ *           description: When the reaction was recorded
+ *         source:
+ *           type: string
+ *           description: Source system that emitted the reaction event
+ *         metadata:
+ *           type: object
+ *           additionalProperties: true
+ *           description: Optional payload for debugging/tracing the event
+ *
+ *     ReactionSummary:
+ *       type: object
+ *       properties:
+ *         range:
+ *           type: object
+ *           properties:
+ *             start:
+ *               type: string
+ *               format: date-time
+ *             end:
+ *               type: string
+ *               format: date-time
+ *         totals:
+ *           type: object
+ *           properties:
+ *             messagesAnalyzed:
+ *               type: integer
+ *             messagesWithReactions:
+ *               type: integer
+ *             uniqueRecipients:
+ *               type: integer
+ *             totalDeliveries:
+ *               type: integer
+ *             totalReactions:
+ *               type: integer
+ *             uniqueReactors:
+ *               type: integer
+ *             positiveReactions:
+ *               type: integer
+ *             negativeReactions:
+ *               type: integer
+ *             neutralReactions:
+ *               type: integer
+ *             netScore:
+ *               type: integer
+ *         rates:
+ *           type: object
+ *           properties:
+ *             reactionPerDelivery:
+ *               type: number
+ *             reactionPerMessage:
+ *               type: number
+ *             uniqueEngagementRate:
+ *               type: number
+ *             positivityRate:
+ *               type: number
+ *             coverageRate:
+ *               type: number
+ *         breakdown:
+ *           type: array
+ *           items:
+ *             type: object
+ *             properties:
+ *               reaction:
+ *                 type: string
+ *               count:
+ *                 type: integer
+ */
+
+/**
+ * @swagger
+ * /api/reactions:
+ *   get:
+ *     summary: List recorded reactions
+ *     tags: [Reactions]
+ *     security:
+ *       - basicAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 100
+ *       - in: query
+ *         name: message_id
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: user_id
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: reaction
+ *         schema:
+ *           type: string
+ *           enum: ['👍', '❤️', '👎']
+ *       - in: query
+ *         name: source
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: since
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *       - in: query
+ *         name: until
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *     responses:
+ *       200:
+ *         description: Paginated list of reactions
+ */
+router.get('/', authMiddleware, authorizeRole(['superadmin', 'admin', 'viewer']), reactionController.list);
+
+/**
+ * @swagger
+ * /api/reactions:
+ *   post:
+ *     summary: Record a reaction event
+ *     tags: [Reactions]
+ *     security:
+ *       - basicAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/MessageReaction'
+ *     responses:
+ *       201:
+ *         description: Reaction recorded
+ */
+router.post('/', authMiddleware, authorizeRole(['superadmin', 'admin']), reactionController.create);
+
+/**
+ * @swagger
+ * /api/reactions/summary:
+ *   get:
+ *     summary: Get engagement summary for a timeframe
+ *     tags: [Reactions]
+ *     security:
+ *       - basicAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: timeframe
+ *         schema:
+ *           type: string
+ *           example: 30d
+ *         description: Relative timeframe (e.g. 24h, 7d, 1y)
+ *       - in: query
+ *         name: since
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Absolute start date (overrides timeframe)
+ *       - in: query
+ *         name: until
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Absolute end date (overrides timeframe)
+ *     responses:
+ *       200:
+ *         description: Engagement summary
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ReactionSummary'
+ */
+router.get('/summary', authMiddleware, authorizeRole(['superadmin', 'admin', 'viewer']), reactionController.getSummary);
+
+/**
+ * @swagger
+ * /api/reactions/messages/{messageId}:
+ *   get:
+ *     summary: Get engagement metrics for a specific message
+ *     tags: [Reactions]
+ *     security:
+ *       - basicAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: messageId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Message engagement details
+ */
+router.get('/messages/:messageId', authMiddleware, authorizeRole(['superadmin', 'admin', 'viewer']), reactionController.getMessageSummary);
+
+/**
+ * @swagger
+ * /api/reactions/users/{userId}:
+ *   get:
+ *     summary: Get engagement profile for a specific user
+ *     tags: [Reactions]
+ *     security:
+ *       - basicAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: User engagement profile
+ */
+router.get('/users/:userId', authMiddleware, authorizeRole(['superadmin', 'admin', 'viewer']), reactionController.getUserSummary);
+
+export default router;

--- a/src/services/engagementMetricsService.js
+++ b/src/services/engagementMetricsService.js
@@ -1,0 +1,405 @@
+import { Message, MessageReaction, MESSAGE_REACTIONS, UserMessage, UserSeen } from '../models/index.js';
+import { createServiceLogger } from '../utils/logger.js';
+
+const metricsLogger = createServiceLogger('engagement-metrics');
+
+const POSITIVE_REACTIONS = new Set(['👍', '❤️']);
+const NEGATIVE_REACTIONS = new Set(['👎']);
+
+const reactionSortOrder = {
+  '❤️': 0,
+  '👍': 1,
+  '👎': 2
+};
+
+const sortBreakdown = (breakdown) => {
+  return breakdown.slice().sort((a, b) => {
+    const orderA = reactionSortOrder[a.reaction] ?? Number.MAX_SAFE_INTEGER;
+    const orderB = reactionSortOrder[b.reaction] ?? Number.MAX_SAFE_INTEGER;
+    if (orderA === orderB) {
+      return a.reaction.localeCompare(b.reaction);
+    }
+    return orderA - orderB;
+  });
+};
+
+const aggregateReactionBreakdown = async (matchFilter) => {
+  const breakdown = await MessageReaction.aggregate([
+    { $match: matchFilter },
+    {
+      $group: {
+        _id: '$reaction',
+        count: { $sum: 1 }
+      }
+    },
+    {
+      $project: {
+        _id: 0,
+        reaction: '$_id',
+        count: 1
+      }
+    }
+  ]);
+
+  let totalReactions = 0;
+  let positiveReactions = 0;
+  let negativeReactions = 0;
+
+  for (const item of breakdown) {
+    totalReactions += item.count;
+    if (POSITIVE_REACTIONS.has(item.reaction)) {
+      positiveReactions += item.count;
+    }
+    if (NEGATIVE_REACTIONS.has(item.reaction)) {
+      negativeReactions += item.count;
+    }
+  }
+
+  return {
+    totalReactions,
+    positiveReactions,
+    negativeReactions,
+    breakdown: sortBreakdown(breakdown)
+  };
+};
+
+const buildReactionDateFilter = (start, end) => {
+  if (!start && !end) {
+    return undefined;
+  }
+
+  const filter = {};
+  if (start) {
+    filter.$gte = start;
+  }
+  if (end) {
+    filter.$lte = end;
+  }
+  return filter;
+};
+
+const computeDeliveries = async (messageIds) => {
+  if (!messageIds.length) {
+    return { uniqueRecipients: 0, totalDeliveries: 0 };
+  }
+
+  const uniqueRecipients = await UserSeen.countDocuments({ message_ids: { $in: messageIds } });
+
+  if (!uniqueRecipients) {
+    return { uniqueRecipients: 0, totalDeliveries: 0 };
+  }
+
+  const [deliveriesResult] = await UserSeen.aggregate([
+    { $match: { message_ids: { $in: messageIds } } },
+    {
+      $project: {
+        message_ids: {
+          $filter: {
+            input: '$message_ids',
+            as: 'mid',
+            cond: { $in: ['$$mid', messageIds] }
+          }
+        }
+      }
+    },
+    { $unwind: '$message_ids' },
+    {
+      $group: {
+        _id: null,
+        total: { $sum: 1 }
+      }
+    }
+  ]);
+
+  return {
+    uniqueRecipients,
+    totalDeliveries: deliveriesResult?.total ?? 0
+  };
+};
+
+const toMessageId = (value) => {
+  if (typeof value === 'number') {
+    return value;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+export const engagementMetricsService = {
+  async recordReaction({ message_id, user_id, username, reaction, reacted_at, source, metadata }) {
+    metricsLogger.info('Recording reaction', {
+      message_id,
+      user_id,
+      reaction,
+      source
+    });
+
+    const update = {
+      username: username ?? null,
+      reaction,
+      reacted_at: reacted_at ?? new Date(),
+      source: source ?? 'bot-crawler'
+    };
+
+    if (metadata && typeof metadata === 'object') {
+      update.metadata = metadata;
+    } else if (metadata === null) {
+      update.metadata = null;
+    }
+
+    const reactionDoc = await MessageReaction.findOneAndUpdate(
+      { message_id, user_id },
+      {
+        $set: update,
+        $setOnInsert: {
+          message_id,
+          user_id
+        }
+      },
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true
+      }
+    );
+
+    return reactionDoc;
+  },
+
+  async listReactions({ page = 1, limit = 100, messageId, userId, reaction, source, start, end }) {
+    const query = {};
+
+    if (messageId !== undefined && messageId !== null) {
+      const parsedMessageId = toMessageId(messageId);
+      if (parsedMessageId !== null) {
+        query.message_id = parsedMessageId;
+      }
+    }
+
+    if (userId) {
+      query.user_id = userId;
+    }
+
+    if (reaction && MESSAGE_REACTIONS.includes(reaction)) {
+      query.reaction = reaction;
+    }
+
+    if (source) {
+      query.source = source;
+    }
+
+    const dateFilter = buildReactionDateFilter(start, end);
+    if (dateFilter) {
+      query.reacted_at = dateFilter;
+    }
+
+    const skip = (page - 1) * limit;
+
+    const [reactions, total] = await Promise.all([
+      MessageReaction.find(query)
+        .sort({ reacted_at: -1 })
+        .skip(skip)
+        .limit(limit),
+      MessageReaction.countDocuments(query)
+    ]);
+
+    return {
+      data: reactions,
+      pagination: {
+        page,
+        limit,
+        total,
+        pages: Math.ceil(total / limit)
+      }
+    };
+  },
+
+  async getGlobalSummary({ start, end }) {
+    const messageMatch = {};
+    if (start || end) {
+      messageMatch.message_date = {};
+      if (start) {
+        messageMatch.message_date.$gte = start;
+      }
+      if (end) {
+        messageMatch.message_date.$lte = end;
+      }
+    }
+
+    const messages = await Message.find(messageMatch, {
+      message_id: 1,
+      message_date: 1
+    }).lean();
+
+    const messageIds = messages.map((msg) => msg.message_id);
+
+    if (!messageIds.length) {
+      return {
+        range: {
+          start: start ? start.toISOString() : null,
+          end: end ? end.toISOString() : null
+        },
+        totals: {
+          messagesAnalyzed: 0,
+          messagesWithReactions: 0,
+          uniqueRecipients: 0,
+          totalDeliveries: 0,
+          totalReactions: 0,
+          uniqueReactors: 0,
+          positiveReactions: 0,
+          negativeReactions: 0,
+          neutralReactions: 0,
+          netScore: 0
+        },
+        rates: {
+          reactionPerDelivery: 0,
+          reactionPerMessage: 0,
+          uniqueEngagementRate: 0,
+          positivityRate: 0,
+          coverageRate: 0
+        },
+        breakdown: []
+      };
+    }
+
+    const dateFilter = buildReactionDateFilter(start, end);
+    const reactionMatch = {
+      message_id: { $in: messageIds }
+    };
+    if (dateFilter) {
+      reactionMatch.reacted_at = dateFilter;
+    }
+
+    const [breakdown, uniqueReactors, messagesWithReactions, deliveries] = await Promise.all([
+      aggregateReactionBreakdown(reactionMatch),
+      MessageReaction.distinct('user_id', reactionMatch),
+      MessageReaction.distinct('message_id', reactionMatch),
+      computeDeliveries(messageIds)
+    ]);
+
+    const neutralReactions = breakdown.totalReactions - breakdown.positiveReactions - breakdown.negativeReactions;
+
+    return {
+      range: {
+        start: start ? start.toISOString() : null,
+        end: end ? end.toISOString() : null
+      },
+      totals: {
+        messagesAnalyzed: messageIds.length,
+        messagesWithReactions: messagesWithReactions.length,
+        uniqueRecipients: deliveries.uniqueRecipients,
+        totalDeliveries: deliveries.totalDeliveries,
+        totalReactions: breakdown.totalReactions,
+        uniqueReactors: uniqueReactors.length,
+        positiveReactions: breakdown.positiveReactions,
+        negativeReactions: breakdown.negativeReactions,
+        neutralReactions,
+        netScore: breakdown.positiveReactions - breakdown.negativeReactions
+      },
+      rates: {
+        reactionPerDelivery: deliveries.totalDeliveries ? breakdown.totalReactions / deliveries.totalDeliveries : 0,
+        reactionPerMessage: messageIds.length ? breakdown.totalReactions / messageIds.length : 0,
+        uniqueEngagementRate: deliveries.uniqueRecipients ? uniqueReactors.length / deliveries.uniqueRecipients : 0,
+        positivityRate: breakdown.totalReactions ? breakdown.positiveReactions / breakdown.totalReactions : 0,
+        coverageRate: messageIds.length ? messagesWithReactions.length / messageIds.length : 0
+      },
+      breakdown: breakdown.breakdown
+    };
+  },
+
+  async getMessageSummary(messageId) {
+    const numericMessageId = toMessageId(messageId);
+    if (numericMessageId === null) {
+      return null;
+    }
+
+    const message = await Message.findOne({ message_id: numericMessageId }).lean();
+
+    if (!message) {
+      return null;
+    }
+
+    const reactionMatch = { message_id: numericMessageId };
+
+    const [breakdown, uniqueReactors, latestReaction, earliestReaction, deliveries] = await Promise.all([
+      aggregateReactionBreakdown(reactionMatch),
+      MessageReaction.distinct('user_id', reactionMatch),
+      MessageReaction.findOne(reactionMatch).sort({ reacted_at: -1 }).select('reacted_at').lean(),
+      MessageReaction.findOne(reactionMatch).sort({ reacted_at: 1 }).select('reacted_at').lean(),
+      computeDeliveries([numericMessageId])
+    ]);
+
+    const neutralReactions = breakdown.totalReactions - breakdown.positiveReactions - breakdown.negativeReactions;
+
+    return {
+      message: {
+        message_id: message.message_id,
+        message_date: message.message_date,
+        group: message.group,
+        sender: message.sender,
+        message: message.message
+      },
+      totals: {
+        totalReactions: breakdown.totalReactions,
+        uniqueReactors: uniqueReactors.length,
+        positiveReactions: breakdown.positiveReactions,
+        negativeReactions: breakdown.negativeReactions,
+        neutralReactions,
+        netScore: breakdown.positiveReactions - breakdown.negativeReactions,
+        uniqueRecipients: deliveries.uniqueRecipients,
+        totalDeliveries: deliveries.totalDeliveries
+      },
+      rates: {
+        reactionPerDelivery: deliveries.totalDeliveries ? breakdown.totalReactions / deliveries.totalDeliveries : 0,
+        uniqueEngagementRate: deliveries.uniqueRecipients ? uniqueReactors.length / deliveries.uniqueRecipients : 0,
+        positivityRate: breakdown.totalReactions ? breakdown.positiveReactions / breakdown.totalReactions : 0
+      },
+      timeline: {
+        firstReactionAt: earliestReaction?.reacted_at ?? null,
+        lastReactionAt: latestReaction?.reacted_at ?? null
+      },
+      breakdown: breakdown.breakdown
+    };
+  },
+
+  async getUserSummary(userId) {
+    const reactionMatch = { user_id: userId };
+
+    const [breakdown, userSeen, inboundMessages, distinctMessages, latestReaction, earliestReaction] = await Promise.all([
+      aggregateReactionBreakdown(reactionMatch),
+      UserSeen.findOne({ user_id: userId }).lean(),
+      UserMessage.countDocuments({ user_id: userId }),
+      MessageReaction.distinct('message_id', reactionMatch),
+      MessageReaction.findOne(reactionMatch).sort({ reacted_at: -1 }).select('reacted_at').lean(),
+      MessageReaction.findOne(reactionMatch).sort({ reacted_at: 1 }).select('reacted_at').lean()
+    ]);
+
+    const neutralReactions = breakdown.totalReactions - breakdown.positiveReactions - breakdown.negativeReactions;
+    const messagesSeen = userSeen?.message_ids?.length ?? 0;
+
+    return {
+      user: {
+        user_id: userId,
+        username: userSeen?.username ?? null
+      },
+      totals: {
+        totalReactions: breakdown.totalReactions,
+        positiveReactions: breakdown.positiveReactions,
+        negativeReactions: breakdown.negativeReactions,
+        neutralReactions,
+        netScore: breakdown.positiveReactions - breakdown.negativeReactions,
+        messagesReacted: distinctMessages.length,
+        inboundMessages
+      },
+      reach: {
+        messagesSeen,
+        reactionRate: messagesSeen ? distinctMessages.length / messagesSeen : 0
+      },
+      timeline: {
+        firstReactionAt: earliestReaction?.reacted_at ?? null,
+        lastReactionAt: latestReaction?.reacted_at ?? null
+      },
+      breakdown: breakdown.breakdown
+    };
+  }
+};

--- a/src/utils/timeRange.js
+++ b/src/utils/timeRange.js
@@ -1,0 +1,64 @@
+const UNIT_IN_MS = {
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  w: 7 * 24 * 60 * 60 * 1000,
+  mo: 30 * 24 * 60 * 60 * 1000,
+  y: 365 * 24 * 60 * 60 * 1000
+};
+
+const TIMEFRAME_REGEX = /^(\d+)\s*(m|h|d|w|mo|y)$/i;
+
+export const parseRelativeTimeframe = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = String(value).trim().toLowerCase();
+  const match = trimmed.match(TIMEFRAME_REGEX);
+
+  if (!match) {
+    return null;
+  }
+
+  const amount = Number.parseInt(match[1], 10);
+  const unit = match[2];
+
+  if (!Number.isFinite(amount) || amount < 0) {
+    return null;
+  }
+
+  const unitMs = UNIT_IN_MS[unit];
+  if (!unitMs) {
+    return null;
+  }
+
+  return new Date(Date.now() - amount * unitMs);
+};
+
+export const parseDateInput = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date;
+};
+
+export const resolveTimeRange = ({ timeframe, since, until, defaultTimeframe = '30d' } = {}) => {
+  const end = parseDateInput(until) ?? new Date();
+  const start = parseDateInput(since) ?? parseRelativeTimeframe(timeframe ?? defaultTimeframe);
+
+  if (!start || !end) {
+    return null;
+  }
+
+  if (start > end) {
+    return null;
+  }
+
+  return { start, end };
+};


### PR DESCRIPTION
## Summary
- add a Mongo-backed message reaction model along with ingestion and analytics endpoints for reactions
- expose engagement metrics routes with Swagger docs and surface the data set inside AdminJS
- provide a shared time range utility used by the engagement metrics service

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68daf360bc748333b19c681ea83e7673