### PR TITLE
Fix user analytics dashboard import usage

### DIFF
--- a/src/components/UserAnalyticsDashboard.jsx
+++ b/src/components/UserAnalyticsDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+const { useState, useEffect } = React;
 
 const UserAnalyticsDashboard = (props) => {
   const [insights, setInsights] = useState(null);


### PR DESCRIPTION
## Summary
- use the globally provided React instance in the user analytics dashboard component to avoid module import errors in the browser

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd98fafee0833387ab7eb85b6a413a