### PR TITLE
Update reaction rate display formatting

### DIFF
--- a/src/components/UserAnalyticsDashboard.jsx
+++ b/src/components/UserAnalyticsDashboard.jsx
@@ -300,7 +300,7 @@ const UserAnalyticsDashboard = () => {
     {
       key: 'reaction-rate',
       title: 'Reaction Rate',
-      value: `1:${reactionRate ? reactionRate.toFixed(2) : '0.00'}`,
+      value: `${reactionRate.toFixed(2)} reactions/message`,
       color: '#e91e63',
       icon: '💖',
       subtitle: 'Average reactions per message',
@@ -429,12 +429,12 @@ const UserAnalyticsDashboard = () => {
           'Understand how often users chat, react, and connect with each other so you can spot healthy communities or users who may need support.'
         ),
         React.createElement('div', { key: 'engagement-stats', style: { display: 'flex', flexDirection: 'column', gap: '15px' } }, [
-          React.createElement(InsightRow, {
-            key: 'msg-react-ratio',
-            label: 'Message to Reaction Ratio (how often users react)',
-            value: `1:${reactionRate ? reactionRate.toFixed(2) : '0.00'}`,
-            color: '#4facfe'
-          }),
+        React.createElement(InsightRow, {
+          key: 'msg-react-ratio',
+          label: 'Message to Reaction Ratio (how often users react)',
+          value: `${reactionRate.toFixed(2)} reactions/message`,
+          color: '#4facfe'
+        }),
           React.createElement(InsightRow, {
             key: 'dm-success',
             label: 'DM Success Rate (not blocked by cancellation)',


### PR DESCRIPTION
## Summary
- display reaction rate metrics as a plain average value in the dashboard cards
- ensure the message-to-reaction insight row uses the same reactions per message text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0c59a88288333946e8f00fe189dcb